### PR TITLE
Update   `openh264` to version `2.2.0`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "openh264" %}
-{% set version = "2.1.1" %}
+{% set version = "2.2.0" %}
 
 package:
   name: {{ name }}
@@ -8,7 +8,7 @@ package:
 source:
   fn: {{ name }}-v{{ version }}.tar.gz
   url: https://github.com/cisco/openh264/archive/v{{ version }}.tar.gz
-  sha256: af173e90fce65f80722fa894e1af0d6b07572292e76de7b65273df4c0a8be678
+  sha256: e4e5c8ba48e64ba6ce61e8b6e2b76b2d870c74c270147649082feabb40f25905
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,7 +44,7 @@ about:
   license_file: LICENSE
   summary: OpenH264 is a codec library which supports H.264 encoding and decoding
   dev_url: https://github.com/cisco/openh264
-  doc_url: https://github.com/cisco/openh264
+  doc_url: https://github.com/cisco/openh264/tree/master/docs
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
  `openh264` version `2.2.0`
1. - [x] check the upstream

    https://github.com/cisco/openh264/tree/v2.2.0

2. - [x] check the pinnings

    https://github.com/cisco/openh264/blob/v2.2.0/meson.build

3. - [x] check the changelogs

    https://github.com/cisco/openh264/blob/v2.2.0/RELEASES

    The change mentioned were new features or bug fixes

     - Add support for B-slice error concealment
     - Thread decoding support for multi-slice frame
     - SIMD optimization for loongson platform
     - Support the arm64 compilation on Windows and MacOS platform
     - Some Bug fixes for B-frame decoding
     - Some minor bug fixes


4. - [x] additional research

    https://github.com/conda-forge/openh264-feedstock/issues

    There is currently an open issue related to adding support for cisco encoders

    https://github.com/conda-forge/openh264-feedstock/issues/5

5. - [x] verify dev_url
    https://github.com/cisco/openh264

6. - [x] verify doc_url
    https://github.com/cisco/openh264/tree/master/docs

7. - [x] license is spdx compliant
8. - [x] license family
9. - [x] verify the build number
10. - [x] verify setuptools
    `setuptools` is not mentioned in the upstream

11. - [x] verify wheel
    `wheel` is not mentioned in the upstream

12. - [x] pip in the test section
    `pip` is not mentioned in the upstream

13. - [x] veriy the test section

Results:
- All checks have passed

Based on the research findings and the results we can conclude
that it is safe to update `openh264` to version `2.2.0`

